### PR TITLE
Fix chunk size for big configurations

### DIFF
--- a/xs.cc
+++ b/xs.cc
@@ -124,12 +124,12 @@ int xsctl::router_install(const std::string& domain, const std::string& config, 
         for (unsigned int i = 0 ; ; i++) {
             path = router_path + "/config/" + std::to_string(i);
 
-            unsigned int pos = i * XENSTORE_PAYLOAD_MAX;
+            unsigned int pos = i * chunk_max_len;
             if (pos >= config.length()) {
                 break;
             }
 
-            std::string chunk = config.substr(i * XENSTORE_PAYLOAD_MAX, XENSTORE_PAYLOAD_MAX);
+            std::string chunk = config.substr(i * chunk_max_len, chunk_max_len);
 
             if (!xs_write(xsh, xst, path.c_str(), chunk.c_str(), chunk.length())) {
                 ret = errno;

--- a/xs.hh
+++ b/xs.hh
@@ -54,6 +54,13 @@ extern "C" {
 namespace clickos {
 namespace xenstore {
 
+/* Define the maximum length of each configuration chunk written to the
+ * xenstore. Theoretically this value depends only on the xenstore, but ClickOS
+ * is not accepting big chunk sizes, so for now set a value that works.
+ *
+ * TODO: Check whether chunk_max_len can be increased.
+ */
+const unsigned int chunk_max_len = 512;
 const std::string click_base_path = "/data/clickos";
 
 class xsctl {


### PR DESCRIPTION
XENSTORE_PAYLOAD_MAX is the maximum message size that can go into the
xenstore protocol, therefore for a `xs_write` it includes the path and a
null character for separator, so we can't use this macro directly for
chunk size.

We could calculate the chunk size based on the path length, however
ClickOS is not accepting big chunk sizes for some reason. So for now set
the chunk size for a fixed value of 512, that is known to work.

This fixes #3.